### PR TITLE
Avoid lookbehind assertion

### DIFF
--- a/js/format-c2m.js
+++ b/js/format-c2m.js
@@ -290,7 +290,7 @@ export function parse_level(buf) {
                 // for levels with multiple hint tiles, delineated by [CLUE].
                 // For my purposes, extra hints are associated with the
                 // individual tiles, so we'll map those later
-                [level.comment, ...extra_hints] = str.split(/(?<=^|\n)\[CLUE\]\n/g);
+                [level.comment, ...extra_hints] = str.split(/^\[CLUE\]$/mg);
             }
             continue;
         }


### PR DESCRIPTION
The game fails to load under Firefox 77.0 with the very helpful error
message,

    SyntaxError: invalid regexp group   format-c2m.js:1:1

Turns out that it doesn't like the `(?<=^|\n)` lookbehind group in
the CLUE regexp. It seems lookbehind support wasn't added until FF 78,
according to the [big table][1]. Switch it to a multiline regexp instead.

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Browser_compatibility