### PR TITLE
Improve support for High DPI displays

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -619,18 +619,27 @@ class Player extends PrimaryView {
         // The main UI is centered in a flex item with auto margins, so the
         // extra space available is the size of those margins
         let style = window.getComputedStyle(this.root);
+        if (style['display'] === 'none') {
+            // the computed margins can be 'auto' in this case
+            return;
+        }
         let extra_x = parseFloat(style['margin-left']) + parseFloat(style['margin-right']);
         let extra_y = parseFloat(style['margin-top']) + parseFloat(style['margin-bottom']);
         // The total available space, then, is the current size of the
         // canvas plus the size of the margins
         let total_x = extra_x + this.renderer.canvas.offsetWidth;
         let total_y = extra_y + this.renderer.canvas.offsetHeight;
+        let dpr = window.devicePixelRatio || 1.0;
         // Divide to find the biggest scale that still fits.  But don't
         // exceed 90% of the available space, or it'll feel cramped.
-        let scale = Math.floor(0.9 * Math.min(total_x / base_x, total_y / base_y));
-        if (scale <= 0) {
+        let scale = Math.floor(0.9 * dpr * Math.min(total_x / base_x, total_y / base_y));
+        if (scale <= 1) {
             scale = 1;
         }
+        // High DPI support: scale the canvas down by the inverse of the device
+        // pixel ratio, thus matching the canvas's resolution to the screen
+        // resolution and giving us nice, clean pixels.
+        scale /= dpr;
 
         // FIXME the above logic doesn't take into account the inventory, which is also affected by scale
         this.scale = scale;


### PR DESCRIPTION
On high DPI displays, a logical pixel does not necessarily equal a device pixel. Images and such are scaled up to the logical pixel size; unfortunately this introduces ugly aliasing. Web pages can take advantage of high DPI screens by intentionally scaling stuff down to be displayed at a higher resolution. By carefully canceling out the automatic scaling of the game canvas we get nice crisp pixels even on high DPI screens.

**Before:** (125% scaling)

Note the aliasing artifacts in the outlines of the hearts and key cards.
![before DPI scaling](https://user-images.githubusercontent.com/175539/92980351-b20a5400-f44a-11ea-8f62-9f00f240b5a9.png)



**After:** 
![after DPI scaling](https://user-images.githubusercontent.com/175539/92980358-b8003500-f44a-11ea-9ca6-c9d0770d0979.png)
