### PR TITLE
Disable undo during bulk testing

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2173,6 +2173,7 @@ class PackTestDialog extends DialogOverlay {
                 level.sfx = dummy_sfx;
                 level.force_floor_direction = replay.initial_force_floor_direction;
                 level._blob_modifier = replay.blob_seed;
+                level.undo_enabled = false; // slight performance boost
 
                 while (true) {
                     let input = replay.get(level.tic_counter);


### PR DESCRIPTION
Undo generates a lot of garbage. Faster not to.

CC1 bulk test on my laptop:

Firefox 77 speeds up from 61s to 41s
Chrome barely moves, from 34s to 28s