### PR TITLE
Add a missing tile encoding spec for one-way walls

### DIFF
--- a/js/format-c2g.js
+++ b/js/format-c2g.js
@@ -926,6 +926,22 @@ const TILE_ENCODING = {
         modifier: modifier_color,
         is_extension: true,
     },
+    0xf4: {
+        name: 'one_way_walls',
+        has_next: true,
+        is_extension: true,
+        extra_args: [
+            {
+                size: 1,
+                decode(tile, mask) {
+                    tile.edges = mask;
+                },
+                encode(tile) {
+                    return tile.edges;
+                },
+            },
+        ],
+    },
 };
 const REVERSE_TILE_ENCODING = {};
 for (let [tile_byte, spec] of Object.entries(TILE_ENCODING)) {
@@ -2156,7 +2172,7 @@ const MAX_SIMULTANEOUS_REQUESTS = 5;
 
         _fetch_map(path, n);
     };
-    
+
     // FIXME and right off the bat we have an Issue: this is a text format so i want a string, not
     // an arraybuffer!
     let contents = util.string_from_buffer_ascii(buf);


### PR DESCRIPTION
Fix for the problem where you can't save/share levels with one-way walls in them. Tested saving/loading from browser storage, exporting/loading files, and sharing by URL, and all worked for me (in Safari).

I just picked the first free object ID available after the last entry in `TILE_ENCODING` for this. I've looked at this codebase for exactly 34 minutes so I'm not sure if just storing the edges bitmask as an extra byte arg is the most correct way to handle this, but it seemed to work.