### PR TITLE
Fix invisble wall encoding in CCL/DAT files

### DIFF
--- a/js/format-dat.js
+++ b/js/format-dat.js
@@ -124,7 +124,7 @@ const TILE_ENCODING = {
 const REVERSE_TILE_ENCODING = {};
 for (let [tile_byte, spec] of Object.entries(TILE_ENCODING)) {
     tile_byte = parseInt(tile_byte, 10);  // these are keys so they get stringified ugh
-    if (0x36 <= tile_byte && tile_byte <= 0x37) {
+    if (tile_byte === 0x20 || tile_byte === 0x36 || tile_byte === 0x37) {
         // These are unused tiles which get turned into invisible walls; don't encode invisible
         // walls as them!  (0x38 is also "unused", but pgchip turns it into ice block.)
         continue;


### PR DESCRIPTION
The real invisible wall tile 0x05 was getting overwritten by 0x20 in CCL (aka DAT) exports. (is it worth adding some sort overwrite check in the reverse index lookup? probably not but it's what popped in my head)

I also took the liberty of changing the byte-range check to simple equality tests since I think that's clearer in this case &mdash; I hope that's okay!

I noticed this when trying to convert my exported CCL levels to PAK format with [c4](http://www.muppetlabs.com/~breadbox/pub/software/tworld/c4) and it kept complaining about "non-lynx objects". I dug into it & presto bug found bug (hopefully) fixed!